### PR TITLE
Apply AutoConfiguration

### DIFF
--- a/src/main/java/com/marceldev/ourcompanylunchcommon/CommonAutoConfiguration.java
+++ b/src/main/java/com/marceldev/ourcompanylunchcommon/CommonAutoConfiguration.java
@@ -1,0 +1,27 @@
+package com.marceldev.ourcompanylunchcommon;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(prefix = "common.jwt", name = {"secret", "expired-in-hour"})
+public class CommonAutoConfiguration {
+
+  @Value("${common.jwt.secret}")
+  private String secret;
+
+  @Value("${common.jwt.expired-in-hour}")
+  private int expiredInHour;
+
+  @Bean
+  public JwtAuthenticationFilter jwtAuthenticationFilter() {
+    return new JwtAuthenticationFilter(tokenProvider());
+  }
+
+  @Bean
+  public TokenProvider tokenProvider() {
+    return new TokenProvider(expiredInHour, secret);
+  }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.marceldev.ourcompanylunchcommon.CommonAutoConfiguration


### PR DESCRIPTION
### Changes
<!-- Describe what changed in this PR. -->

**AS-IS**
- Each library user needs to define bean.

**TO-BE**
- If a library user register specific properties in application yml, beans will be registered automatically.
```
common:
  jwt:
    secret: l3h48hkl9rahst9n50rarpyutnqu3n489af09tn3pun
    expired-in-hour: 1
```

Resolves #3 